### PR TITLE
remove data:image/jpeg;base64, prefix from base64 image input

### DIFF
--- a/litellm/llms/vertex_ai/multimodal_embeddings/embedding_handler.py
+++ b/litellm/llms/vertex_ai/multimodal_embeddings/embedding_handler.py
@@ -226,7 +226,7 @@ class VertexMultimodalEmbedding(VertexLLM):
             else:
                 return Instance(image=InstanceImage(gcsUri=input_element))
         elif is_base64_encoded(s=input_element):
-            return Instance(image=InstanceImage(bytesBase64Encoded=input_element))
+            return Instance(image=InstanceImage(bytesBase64Encoded=input_element.split(",")[1] if "," in input_element else input_element))            
         else:
             return Instance(text=input_element)
 


### PR DESCRIPTION
vertex_ai's multimodal embeddings endpoint expects a raw base64 string without `data:image/jpeg;base64,` prefix.

## Title

<!-- e.g. "Implement user authentication feature" -->


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Strip out data:image/jpeg;base64, prefix before sending to vertexai.